### PR TITLE
fix(RITE-9637): add fixes to TextInput and TextArea

### DIFF
--- a/src/Test/AppB/Test.Api.AppB/Controllers/WeatherForecastController.cs
+++ b/src/Test/AppB/Test.Api.AppB/Controllers/WeatherForecastController.cs
@@ -7,7 +7,7 @@ public class WeatherForecastController : ControllerBase
 {
     private static readonly string[] Summaries = new[]
     {
-        "Freezing", "Bracing"
+        "Freezing", "Bracing", "Fresh"
     };
 
     private readonly ILogger<WeatherForecastController> _logger;

--- a/src/Test/Core/Test.Core/Math.cs
+++ b/src/Test/Core/Test.Core/Math.cs
@@ -18,7 +18,7 @@ public static class Math
     {
         return x * y;
     }
-    //some comment
+    //some comments
     public static int divide(int x, int y)
     {
         return x / y;


### PR DESCRIPTION
Context
Does this issue have a Jira ticket?

https://westminstergov.atlassian.net/browse/RITE-2637

If this is an issue, do we have steps to reproduce?

Start the storybook by running nx run design-system:storybook and then find the TextInput and TextArea molecules